### PR TITLE
Added check for token environment variable

### DIFF
--- a/cmd/mapper.go
+++ b/cmd/mapper.go
@@ -26,14 +26,13 @@ func main() {
 
 	// No Cli flag for the token, assign from the env var
 	if len(token) == 0 {
-		token = os.Getenv("SECURE_API_TOKEN")
-	}
-
-	// Missing token cli flag or environment variable
-	_, ok := os.LookupEnv("SECURE_API_TOKEN")
-	if !ok {
-		fmt.Println("TOKEN NOT FOUND - Please ensure either the \"SECURE_API_TOKEN\" environment variable or the \"secure-token\" cli flag is set.")
-		os.Exit(1)
+		var ok bool
+		// Missing token cli flag or environment variable
+		_, ok = os.LookupEnv("SECURE_API_TOKEN")
+		if !ok {
+			fmt.Println("TOKEN NOT FOUND - Please ensure either the \"SECURE_API_TOKEN\" environment variable or the \"secure-token\" cli flag is set.")
+			os.Exit(1)
+		}
 	}
 
 	outFile := "policies.html"

--- a/cmd/mapper.go
+++ b/cmd/mapper.go
@@ -32,10 +32,8 @@ func main() {
 	// Missing token cli flag or environment variable
 	_, ok := os.LookupEnv("SECURE_API_TOKEN")
 	if !ok {
-
 		fmt.Println("TOKEN NOT FOUND - Please ensure either the \"SECURE_API_TOKEN\" environment variable or the \"secure-token\" cli flag is set.")
 		os.Exit(1)
-
 	}
 
 	outFile := "policies.html"

--- a/cmd/mapper.go
+++ b/cmd/mapper.go
@@ -23,8 +23,19 @@ func main() {
 
 	token := ""
 	cli.StringFlag("secure-token", "API token for Sysdig Secure (env: SECURE_API_TOKEN)", &token)
+
+	// No Cli flag for the token, assign from the env var
 	if len(token) == 0 {
 		token = os.Getenv("SECURE_API_TOKEN")
+	}
+
+	// Missing token cli flag or environment variable
+	_, ok := os.LookupEnv("SECURE_API_TOKEN")
+	if !ok {
+
+		fmt.Println("TOKEN NOT FOUND - Please ensure either the \"SECURE_API_TOKEN\" environment variable or the \"secure-token\" cli flag is set.")
+		os.Exit(1)
+
 	}
 
 	outFile := "policies.html"


### PR DESCRIPTION
Hey Patrick, quick and dirty check to see if the environment variable exists.

- since the previous "if" checks for the cli flag and sets the env var token, we can assume the environment variable should be set at this point. We then check for the environment variable to see if it is set. If the token is not set at this point, display a message and exit out (1). 
- there likely is a better solution?